### PR TITLE
Replace 'data' with 'document' in send params

### DIFF
--- a/tg_logger/files.py
+++ b/tg_logger/files.py
@@ -43,7 +43,7 @@ class TgFileLogger:
                 t0 = time()
                 while time() - t0 < self.timeout:
                     try:
-                        self.bot.send_document(user_id, data=data, caption=caption, parse_mode="HTML")
+                        self.bot.send_document(user_id, document=data, caption=caption, parse_mode="HTML")
                         logger.info("File %s successfully send to %s", file_path, user_id)
                         break
                     except Exception:


### PR DESCRIPTION
https://pytba.readthedocs.io/en/latest/sync_version/index.html?highlight=send_document#telebot.TeleBot.send_document
Тут в параметрах указан только 'document', 'data' отсутствует, при запуске send выдает ошибку.